### PR TITLE
Fixed to allow subscription to any topic

### DIFF
--- a/tools/test_ros.py
+++ b/tools/test_ros.py
@@ -93,6 +93,7 @@ def parse_config():
     parser = argparse.ArgumentParser(description='arg parser')
 
     parser.add_argument('--pt', type=str, default=None, help='checkpoint to start from')
+    parser.add_argument('--subscribe', type=str, default='/livox/lidar', help='subscribe topic')
 
     args = parser.parse_args()
     return args
@@ -184,7 +185,7 @@ if __name__ == '__main__':
 
     demo_ros = ros_demo(model, args)
     sub = rospy.Subscriber(
-        "/livox/lidar", PointCloud2, queue_size=10, callback=demo_ros.online_inference)
+        args.subscribe, PointCloud2, queue_size=10, callback=demo_ros.online_inference)
     print("set up subscriber!")
 
     rospy.spin()


### PR DESCRIPTION
Thank you for your great project!

Since `livox_detection` is a great project, object detection should be performed on a variety of point clouds. That is, it should be possible to subscribe to a filtered topic or a third-party LiDAR topic.

Therefore, I fixed to allow subscription to any topic as an argument.
Of course, as before, if nothing is specified, `/livox/lidar` will be subscribed to.